### PR TITLE
Removing extra continue after print statements

### DIFF
--- a/models/tridimensional/cas9_PAM_scoring.py
+++ b/models/tridimensional/cas9_PAM_scoring.py
@@ -37,7 +37,6 @@ for i in range(0, 64):
 		if os.path.isfile(results_file): continue
 
 		print "Running for: " + variant + "_" + program
-		continue
 		# Start keeping track of runtime
 		time_init = time()
 		test_pose = pose_from_pdb(program + "/4UN3." + variant + ".pdb")


### PR DESCRIPTION
Looks like you forgot to remove it when just testing some stuff. Took me
a little bit to find out why things were racing through and finishing in
less than a second

And when using windows, use \ for directories. Windows uses backslashes, and you need to make sure you don't escape other characters in the string
