### PR TITLE
Include new script mutate_pdb.py, update dock_variant.py

### DIFF
--- a/models/tridimensional/docking_validation/dock_variants.py
+++ b/models/tridimensional/docking_validation/dock_variants.py
@@ -98,7 +98,7 @@ def dock_variants(pam_variants, path_to_scores, path_to_pdbs='', complex_docking
             time_init = time()
             loaded_pose = pose_from_pdb(pdb_path)
             if complex_docking_flag:
-                dock_complex(pose)
+                dock_complex(loaded_pose)
             else:
                 dock_stats = dock_simple(loaded_pose)
             time_final = time()

--- a/models/tridimensional/docking_validation/dock_variants.py
+++ b/models/tridimensional/docking_validation/dock_variants.py
@@ -47,8 +47,8 @@ def dock_simple(pose):
     setup_foldtree(pose, 'B_CD', Vector1([1]))
 
     # specify scoring functions
-    fa_score = get_fa_scorefxn()  # standard full atom score
-    dna_score = create_score_function('dna')  # 
+    fa_score = get_fa_scorefxn()
+    dna_score = create_score_function('dna')
     dna_score.set_weight(fa_elec, 1)
 
     # specify docking protocol
@@ -125,7 +125,7 @@ if __name__ == '__main__':
     args = parser.parse_args()
     
     # setup range of pam variants   
-    assert 0 <= args.start < args.end <= 63
+    assert 0 <= args.start <= args.end <= 63
     pam_variants_to_score = range(args.start, args.end + 1)
 
     # setup output path for scoring

--- a/models/tridimensional/docking_validation/dock_variants.py
+++ b/models/tridimensional/docking_validation/dock_variants.py
@@ -42,10 +42,8 @@ def dock_simple(pose):
     Potential Bugs:
     - setup_foldtree(...) crashes on some systems/configurations
     - docking.set_partners(...) may not be needed
+    - use default foldtree (foldtree from pdb) for now
     """
-    # specify foldtree for simple docking
-    setup_foldtree(pose, 'B_CD', Vector1([1]))
-
     # specify scoring functions
     fa_score = get_fa_scorefxn()
     dna_score = create_score_function('dna')
@@ -122,6 +120,8 @@ if __name__ == '__main__':
                         help='path to root of variant pdb directories (default: "")')
     parser.add_argument('--complex', metavar='B', nargs='?', const=True, default=False,
                         type=str, help='[switch] select complex docking (default: "False")')
+    parser.add_argument('--csv', metavar='B', nargs='?', const=True, default=False,
+                        type=str, help='[switch] compile scores to csv (default: "False")')
     args = parser.parse_args()
     
     # setup range of pam variants   
@@ -130,10 +130,8 @@ if __name__ == '__main__':
 
     # setup output path for scoring
     if args.output_dir is not None:
-        compile_csv_flag = False
         path_to_scores = args.output_dir
     else:
-        compile_csv_flag = True
         results_folder = "results"
         timestamp = datetime.datetime.now().strftime("%Y-%m-%d %I.%M.%S%p")
         path_to_scores = "results" + os.sep + timestamp + os.sep
@@ -145,5 +143,5 @@ if __name__ == '__main__':
     dock_variants(pam_variants_to_score, path_to_scores, path_to_pdbs=args.pdb_dir, complex_docking_flag=args.complex)
 
     # collect score txt files into a csv
-    if compile_csv_flag:
+    if args.csv:
         results_to_csv(path_to_scores)

--- a/models/tridimensional/docking_validation/mutate_pdb.py
+++ b/models/tridimensional/docking_validation/mutate_pdb.py
@@ -5,7 +5,7 @@ from toolbox import mutate_residue
 
 
 def mutate_pose(pose, mutations):
-    """Applies list of mutations to the given pose and returns a pdb
+    """Applies list of mutations to the given template pose and returns a mutated version
     Args:
         pose: PyRosetta Pose() object representing a loaded pdb structure
         mutations: list of amino acid swaps to apply, format is: [(int, char), ..., (int, char)]
@@ -18,7 +18,7 @@ def mutate_pose(pose, mutations):
     mutant_pose = Pose()
     mutant_pose.assign(pose)
     for aa_num, aa_replacement in mutations:
-        assert isinstance(aa_num, int)  # could also check that the residue number is an amino acid and in range? note pose residue != cas9 residue
+        assert isinstance(aa_num, int)
         assert isinstance(aa_replacement, str) and len(aa_replacement) == 1
         mutate_residue(mutant_pose, aa_num, aa_replacement)
     return mutant_pose

--- a/models/tridimensional/docking_validation/mutate_pdb.py
+++ b/models/tridimensional/docking_validation/mutate_pdb.py
@@ -20,7 +20,7 @@ def mutate_pose(pose, mutations):
     for aa_num, aa_replacement in mutations:
         assert isinstance(aa_num, int)
         assert isinstance(aa_replacement, str) and len(aa_replacement) == 1
-        mutate_residue(mutant_pose, aa_num, aa_replacement)
+        mutant_pose = mutate_residue(mutant_pose, aa_num, aa_replacement)
         # kims lines from D050 example
         # =================================
         pose_packer = standard_packer_task(mutant_pose)
@@ -45,12 +45,12 @@ def mutate_pdb(input_pdb_path, mutations, output_directory, output_id):
     """
     pose_template = pose_from_pdb(input_pdb_path)
     pose_mutant = mutate_pose(pose_template, mutations)
-    if not os.path.exists(output_directory_path):
-        os.makedirs(output_directory_path)    
+    if not os.path.exists(output_directory):
+        os.makedirs(output_directory)
     output_pdb_path = os.path.join(output_directory, output_id + ".pdb")
     mutant_pose.dump(output_pdb_path)
     return output_pdb_path
 
     
-if __name__ == '__main__:
+if __name__ == '__main__':
     print "main behaviour not yet implemented"

--- a/models/tridimensional/docking_validation/mutate_pdb.py
+++ b/models/tridimensional/docking_validation/mutate_pdb.py
@@ -21,6 +21,14 @@ def mutate_pose(pose, mutations):
         assert isinstance(aa_num, int)
         assert isinstance(aa_replacement, str) and len(aa_replacement) == 1
         mutate_residue(mutant_pose, aa_num, aa_replacement)
+        # kims lines from D050 example
+        # =================================
+        pose_packer = standard_packer_task(mutant_pose)
+        pose_packer.restrict_to_repacking()
+        scorefxn = get_fa_scorefxn()
+        packmover = PackRotamersMover(scorefxn, pose_packer)
+        packmover.apply(test_pose)
+        # =================================
     return mutant_pose
 
 

--- a/models/tridimensional/docking_validation/mutate_pdb.py
+++ b/models/tridimensional/docking_validation/mutate_pdb.py
@@ -27,7 +27,7 @@ def mutate_pose(pose, mutations):
         pose_packer.restrict_to_repacking()
         scorefxn = get_fa_scorefxn()
         packmover = PackRotamersMover(scorefxn, pose_packer)
-        packmover.apply(test_pose)
+        packmover.apply(mutant_pose)
         # =================================
     return mutant_pose
 

--- a/models/tridimensional/docking_validation/mutate_pdb.py
+++ b/models/tridimensional/docking_validation/mutate_pdb.py
@@ -1,0 +1,48 @@
+import os
+
+from rosetta import *
+from toolbox import mutate_residue
+
+
+def mutate_pose(pose, mutations):
+    """Applies list of mutations to the given pose and returns a pdb
+    Args:
+        pose: PyRosetta Pose() object representing a loaded pdb structure
+        mutations: list of amino acid swaps to apply, format is: [(int, char), ..., (int, char)]
+                   where char is a string of length 1 in "ACDEFGHIKLMNPQRSTVWY"
+    Returns:
+        mutant_pose containing the specified amino acid swaps
+    Notes:
+        - this procedure doesn't modify the input pose
+    """
+    mutant_pose = Pose()
+    mutant_pose.assign(pose)
+    for aa_num, aa_replacement in mutations:
+        assert isinstance(aa_num, int)  # could also check that the residue number is an amino acid and in range? note pose residue != cas9 residue
+        assert isinstance(aa_replacement, str) and len(aa_replacement) == 1
+        mutate_residue(mutant_pose, aa_num, aa_replacement)
+    return mutant_pose
+
+
+def mutate_pdb(input_pdb_path, mutations, output_directory, output_id):
+    """Create a new pdb (<output_filename>.pdb) in the output directory containing specified mutations
+    Args:
+        input_pdb_path: [string] pdb file for template pose (apply mutations to the template)
+        mutations: list of amino acid swaps to apply, format is: [(int, char), ..., (int, char)]
+                   where str is a character in "ACDEFGHIKLMNPQRSTVWY"
+        output_directory: [string] directory to store output pdb file in (e.g. "mutants/some_category/")
+        output_id: [string] filename of mutant, do not include ".pdb" (e.g. "some_mutant_id")
+    Returns:
+        full filepath to the output pdb with the specified mutations
+    """
+    pose_template = pose_from_pdb(input_pdb_path)
+    pose_mutant = mutate_pose(pose_template, mutations)
+    if not os.path.exists(output_directory_path):
+        os.makedirs(output_directory_path)    
+    output_pdb_path = os.path.join(output_directory, output_id + ".pdb")
+    mutant_pose.dump(output_pdb_path)
+    return output_pdb_path
+
+    
+if __name__ == '__main__:
+    print "main behaviour not yet implemented"

--- a/models/tridimensional/docking_validation/mutate_pdb.py
+++ b/models/tridimensional/docking_validation/mutate_pdb.py
@@ -48,7 +48,7 @@ def mutate_pdb(input_pdb_path, mutations, output_directory, output_id):
     if not os.path.exists(output_directory):
         os.makedirs(output_directory)
     output_pdb_path = os.path.join(output_directory, output_id + ".pdb")
-    mutant_pose.dump(output_pdb_path)
+    pose_mutant.dump(output_pdb_path)
     return output_pdb_path
 
     

--- a/models/tridimensional/docking_validation/mutate_pdb.py
+++ b/models/tridimensional/docking_validation/mutate_pdb.py
@@ -18,17 +18,26 @@ def mutate_pose(pose, mutations):
     mutant_pose = Pose()
     mutant_pose.assign(pose)
     for aa_num, aa_replacement in mutations:
+        # ensure mutation is valid and apply it
         assert isinstance(aa_num, int)
         assert isinstance(aa_replacement, str) and len(aa_replacement) == 1
         mutant_pose = mutate_residue(mutant_pose, aa_num, aa_replacement)
-        # kims lines from D050 example
-        # =================================
+        # specify a pose packer to repack the mutation region
         pose_packer = standard_packer_task(mutant_pose)
         pose_packer.restrict_to_repacking()
-        scorefxn = get_fa_scorefxn()
-        packmover = PackRotamersMover(scorefxn, pose_packer)
-        packmover.apply(mutant_pose)
         # =================================
+        # mark's hack segment
+        # =================================
+        # This is a hack, but I want to test. Can't set a movemap, resfiles
+        # might be the way to go. Freeze all residues.
+        pose_packer.temporarily_fix_everything()
+        # Let's release the PI domain
+        for i in range(1110, 1388):
+            pose_packer.temporarily_set_pack_residue(i, True)
+        # =================================
+        # specify the rotamer mover and apply repacking
+        packmover = PackRotamersMover(get_fa_scorefxn(), pose_packer)
+        packmover.apply(mutant_pose)
     return mutant_pose
 
 


### PR DESCRIPTION
New scripts: mutate_pdb.py
Updated scripts: dock_variants.py 

mutate_pdb.py
- this is a functionalized adaptation of kims script "cas9-AA-subst.py"
- can apply a list of mutations to a given pdb to create a new pdb
- main not implemented but an argparser to specify a input pdb, mutation list, and output path might be next / during this PR
- ISSUE: untested -- im not sure how mutate_residue works / what the expected behaviour is
- ISSUE: untested -- have not tested io stuff at all
- ISSUE: not sure if mutant.dump_pose(path) is sufficient or if we should/have to write some pdb metadata before writing the pdb

dock_variants.py
- added empty complex docking function for later
- option to specify root of pdb file directories (Chimera and 3DNA folders) using `--pdb_dir`
  - this param defaults to `''` and corresponds to the current directory (i.e. the script assumes it is beside the folders chimera and 3DNAwhich contain the pam variants)
- option to specify a batch output directory for variant score .txt files using `--output_dir`
  - this param defaults to `None` and corresponds to a timestamped output directory within a folder called "results" beside the script
- option to specify --complex to use complex docking instead of simple
  - this param is off by default and is taken as `False`

TODO next PR:
- create batch and bash files for multiprocessing / compilation
