### PR TITLE
Add wiki folder and citetag.js written by @rollends

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,5 @@ headed by Tessa Alexanian ([@alexanian](http://github.com/alexanian)) and Matt S
 * **models** is where the math subteams keep their models and simulations  
 * **tools** contains code and data related to other aspects of the project  
 * **training** is a messy sandbox of code written during our training sessions  
+* **wiki** is JS/CSS for our wiki, draft content is on
+  (the repo's wiki)[http://github.com/igem-waterloo/uwaterloo-igem-2015/wiki]

--- a/wiki/README.md
+++ b/wiki/README.md
@@ -1,0 +1,5 @@
+# wiki
+
+Content for the [2015 Waterloo iGEM Wiki](http://2015.igem.org/Team:Waterloo) is being drafted on
+[this repository's wiki](http://github.com/igem-waterloo/uwaterloo-igem-2015/wiki). This folder is for wiki code (JS,
+LESS, etc.) rather than cotent.

--- a/wiki/citetag.js
+++ b/wiki/citetag.js
@@ -1,0 +1,16 @@
+<html>
+<body>
+<script type="text/javascript">
+
+$( "cite" ).each(
+  function( index) {
+    var name = "#Citation_" + $(this).attr("ref");
+    $(this).html( "<a href=\"" + name + "\">" + $(name).text() + "</a>" );
+  }
+);
+
+$( ":target" ).css( "background-color", "palegoldenrod" );
+
+</script>
+</body>
+</html>


### PR DESCRIPTION
Starting the wiki folder. I found the citation script written by @rollends last year. How it works:
1. Include an HTML template like the one found on [last year's wiki](http://2014.igem.org/Template:Team:Waterloo/Modeling/Citations). Each citation should have a format like:
   
   `<b id="Citation_Qi2013">[8]</b>L. S. Qi et al. “Repurposing CRISPR as an RNA-guided platform for sequence-specific control of gene expression”. In: <i>Cell</i> 152.5 (Feb. 2013), pp. 1173–1183.`
   
   Quoting from Rollen last year:
   
   > "The 'id' of the bold tag allows the Citation Script to find which index the citation belongs to and allows the script to link to it. Fill the bold tag with the appropriate index, probably one that is not used in order to reduce confusion :) ! Text following the bold tag should be the actual bib style reference."
2. Where you want to cite a reference, enter `<cite ref="Qi2013"></cite>` and the script will fill the `cite` tag with a link to the bottom of the page, where the references template HTML appears.

What this script **doesn't** do is only showing the references that are actually cited on a given page. So we should have some `display: none` properties in the citation tags. This would also require some modification if we still want ordinal citations, since we'll have to calculate the numbers individually for each page.
