### PR TITLE
Generate PDBs with new PAMs given PDB with Cas9 variant

### DIFF
--- a/models/tridimensional/docking_validation/batch_dock.sh
+++ b/models/tridimensional/docking_validation/batch_dock.sh
@@ -2,13 +2,16 @@
 
 RESULTS=~/working/results
 SCRIPTS=~/working/scripts
+LOGGING=~/working/results/batch/log
 
 # require two input arguments
 threads=$1
 label=$2
-if [ -z "$1" ] || [ -z "$2" ]; then
-	echo "ERROR: requires two arguments (threads, label)"
-	echo "Example: bash batch_dock.sh 50 validation_1"
+pdb_dir=$3
+
+if [ -z "$1" ] || [ -z "$2" ] || [ -z "$3" ]; then
+	echo "ERROR: requires three arguments (threads, label, pdb_dir)"
+	echo "Example: bash batch_dock.sh 50 validation_1 ~/pdb/setA/"
 	exit 1
 fi
 
@@ -20,7 +23,7 @@ if [ -d $results_dir ]; then
 fi
 
 pam_start=0
-pam_end=63
+pam_end=255
 range=$(($pam_end-$pam_start+1))
 step=$(($range/$threads))
 remainder=$(($range % $threads))
@@ -41,7 +44,9 @@ while [ $i -lt $threads ]; do
 	fi
 	pam_first=$(($pam_last+1))
 	pam_last=$(($pam_first+$step+$remainder_plus-1))
-	python $SCRIPTS/dock_variants.py -s=$pam_first -e=$pam_last --output_dir=$results_dir &
+	log_name="$LOGGING/$(($label))_pf_$(($pam_first))_pl_$(($pam_last))_thread_$(($i))" # name for logging stdout and stderr
+
+	nohup python $SCRIPTS/dock_variants.py -s=$pam_first -e=$pam_last --output_dir=$results_dir --pdb_dir=$pdb_dir > $(($log_name))_out.txt 2> $(($log_name))_err.txt &
 	pids+=($!)
 	i=$(($i+1))
 done

--- a/models/tridimensional/docking_validation/batch_dock.sh
+++ b/models/tridimensional/docking_validation/batch_dock.sh
@@ -44,9 +44,18 @@ while [ $i -lt $threads ]; do
 	fi
 	pam_first=$(($pam_last+1))
 	pam_last=$(($pam_first+$step+$remainder_plus-1))
-	log_name="$LOGGING/$(($label))_pf_$(($pam_first))_pl_$(($pam_last))_thread_$(($i))" # name for logging stdout and stderr
+	log_name="$LOGGING/$label"
+	log_name+="_pf_$pam_first"
+	log_name+="_pl_$pam_last"
+	log_name+="_thread_$i" # name for logging stdout and stderr
 
-	nohup python $SCRIPTS/dock_variants.py -s=$pam_first -e=$pam_last --output_dir=$results_dir --pdb_dir=$pdb_dir > $(($log_name))_out.txt 2> $(($log_name))_err.txt &
+	out_name=$log_name
+	out_name+="_out.txt"
+
+	err_name=$log_name
+	err_name+="_err.txt"
+
+	python $SCRIPTS/dock_variants.py -s=$pam_first -e=$pam_last --output_dir=$results_dir --pdb_dir=$pdb_dir > $out_name 2> $err_name &
 	pids+=($!)
 	i=$(($i+1))
 done

--- a/models/tridimensional/docking_validation/chimera_generate_pams.py
+++ b/models/tridimensional/docking_validation/chimera_generate_pams.py
@@ -1,3 +1,6 @@
+from __future__ import print_function
+import sys
+
 import os
 import argparse
 import math
@@ -14,8 +17,8 @@ def mutate_nt(pam_idx, base):
         pam_idx: the index of the PAM nucleotide to be modified
         base: what the nt at pam_idx will be changed to
     """
-    position_idx = { 0 : "5.d", 1 : "6.d", 2 : "7.d"} # Nucleotides we want to mutate are located at positions 5,6,7 in chain D (PAM,NGG) and 8,7,6 in chain C (target strand, NCC).
-    position_pairs = { "5.d" : "8.c", "6.d" : "7.c", "7.d" : "6.c"} # Create a dictionary mapping corresponding positions to each other.
+    position_idx = { 0 : "5.d", 1 : "6.d", 2 : "7.d", 3 : "8.d"} # Nucleotides we want to mutate are located at positions 5,6,7 in chain D (PAM,NGG) and 8,7,6 in chain C (target strand, NCC).
+    position_pairs = { "5.d" : "8.c", "6.d" : "7.c", "7.d" : "6.c", "8.d" : "5.c"} # Create a dictionary mapping corresponding positions to each other.
     base_pairs = {'a' : 't', 'c' : 'g', 'g' : 'c', 't' : 'a'} # Create dictionary mapping valid base pairs to each other.
 
     pos = position_idx[pam_idx]
@@ -60,10 +63,13 @@ if __name__ == '__main__':
 
 
     for i in xrange(args.num_pams):
-        if 4 == pam_length:
+        if 3 == pam_length:
             pam = DNA_ALPHABET[i / 16] + DNA_ALPHABET[i / 4 % 4] + DNA_ALPHABET[i % 4]
-        else:
+        elif 4 == pam_length:
             pam = DNA_ALPHABET[i / 64] + DNA_ALPHABET[i / 16 % 4] + DNA_ALPHABET[i / 4 % 4] + DNA_ALPHABET[i % 4]
+        else:
+            print("Unexpected PAM length = %d" %(pam_length), file=sys.stderr)
+            sys.exit()
 
         # open up the file again each time, for now
         runCommand("open " + args.input_pdb)

--- a/models/tridimensional/docking_validation/chimera_generate_pams.py
+++ b/models/tridimensional/docking_validation/chimera_generate_pams.py
@@ -1,9 +1,10 @@
 from __future__ import print_function
-import sys
 
+import sys
 import os
 import argparse
 import math
+import errno
 
 import chimera
 from chimera import runCommand

--- a/models/tridimensional/docking_validation/chimera_generate_pams.py
+++ b/models/tridimensional/docking_validation/chimera_generate_pams.py
@@ -68,9 +68,6 @@ if __name__ == '__main__':
         else:
             pam = dna_nts[i / 64] + dna_nts[i / 16 % 4] + dna_nts[i / 4 % 4] + dna_nts[i % 4]
 
-        # TGG PAM site already exists, let's skip it
-        if original_pam_sequence == pam:
-            continue
         # open up the file again each time, for now
         runCommand("open " + args.input_pdb)
 

--- a/models/tridimensional/docking_validation/chimera_generate_pams.py
+++ b/models/tridimensional/docking_validation/chimera_generate_pams.py
@@ -60,25 +60,25 @@ if __name__ == '__main__':
     if not os.path.exists(args.output_dir):
         os.makedirs(args.output_dir)
 
-for i in xrange(args.num_pams):
-    if 64 == args.num_pams:
-        pam = dna_nts[i / 16] + dna_nts[i / 4 % 4] + dna_nts[i % 4]
-    else:
-        pam = dna_nts[i / 64] + dna_nts[i / 16 % 4] + dna_nts[i / 4 % 4] + dna_nts[i % 4]
+    for i in xrange(args.num_pams):
+        if 64 == args.num_pams:
+            pam = dna_nts[i / 16] + dna_nts[i / 4 % 4] + dna_nts[i % 4]
+        else:
+            pam = dna_nts[i / 64] + dna_nts[i / 16 % 4] + dna_nts[i / 4 % 4] + dna_nts[i % 4]
 
-    # TGG PAM site already exists, let's skip it
-    if "tgg" == pam:
-        continue
-    # open up the file again each time, for now
-    runCommand("open " + args.input_pdb)
-    # Loop through the PAM sequence and mutate positions
-    for n in xrange(int(math.log(args.num_pams, 4))):
-        # If the first base is T, don't mutate
-        if 't' == pam[n] and n == 0:
+        # TGG PAM site already exists, let's skip it
+        if "tgg" == pam:
             continue
-        # If the 2nd or third bases are G, don't mutate
-        if 'g' == pam[n] and (1 == n or 2 == n):
-            continue
-        mutate_nt(n, pam[n])
-    # Save and close all files
-    generate_pdb(os.path.basename(args.input_pdb), pam)
+        # open up the file again each time, for now
+        runCommand("open " + args.input_pdb)
+        # Loop through the PAM sequence and mutate positions
+        for n in xrange(int(math.log(args.num_pams, 4))):
+            # If the first base is T, don't mutate
+            if 't' == pam[n] and n == 0:
+                continue
+            # If the 2nd or third bases are G, don't mutate
+            if 'g' == pam[n] and (1 == n or 2 == n):
+                continue
+            mutate_nt(n, pam[n])
+        # Save and close all files
+        generate_pdb(os.path.basename(args.input_pdb), pam)

--- a/models/tridimensional/docking_validation/chimera_generate_pams.py
+++ b/models/tridimensional/docking_validation/chimera_generate_pams.py
@@ -1,0 +1,82 @@
+import os
+import argparse
+import chimera
+from chimera import runCommand
+from chimera import replyobj
+
+os.chdir("C:\\Users\\James\\Documents\\GitHub\\uwaterloo-igem-2015\\models\\tridimensional\\cas9_modification")
+original_pdb_path = "4UN3.clean.pdb"
+dna_nts = ['a','c','g','t']
+
+
+def mutate_nt(pam_idx, base):
+    """Mutate a base pair at pam_idx to base
+    Args:
+        pam_idx: the index of the PAM nucleotide to be modified
+        base: what the nt at pam_idx will be changed to
+    """
+    position_idx = { 0 : "5.d", 1 : "6.d", 2 : "7.d"} # Nucleotides we want to mutate are located at positions 5,6,7 in chain D (PAM,NGG) and 8,7,6 in chain C (target strand, NCC).
+    position_pairs = { "5.d" : "8.c", "6.d" : "7.c", "7.d" : "6.c"} # Create a dictionary mapping corresponding positions to each other.
+    base_pairs = {'a' : 't', 'c' : 'g', 'g' : 'c', 't' : 'a'} # Create dictionary mapping valid base pairs to each other.
+
+    pos = position_idx[pam_idx]
+    complement_base = base_pairs[base]
+    complement_pos = position_pairs[pos]
+    runCommand("swapna " + base + " : " + pos )
+    runCommand("swapna " + complement_base + " : " + complement_pos)
+
+def generate_pdb(original_pdb_path, pam_seq):
+    """Generate a new PDB file
+    Args:
+        original_pdb_path: original fine basename
+        pam_seq: new PAM sequence to be listed in name
+    """
+    new_pdb_path = os.path.join(args.output_dir, original_pdb_path[:4] + "." + pam_seq + ".pdb")
+    runCommand("write 0 " + new_pdb_path)
+    runCommand("close all")
+
+
+if __name__ == '__main__':
+    # create parser and parse arguments
+    parser = argparse.ArgumentParser(description='Generate PDBs with new PAM sites based on input PDB with Cas9 variant')
+    parser.add_argument('-n', '--num_pams', metavar='N', type=str, # string type because of how this script must be run by Chimera
+                        help='how many PAMs in total to run. 64 = all PAMs of length 3, 256 = all PAMs of length 4')
+    parser.add_argument('-i', '--input_pdb', metavar='F', type=str,
+                        help='input PDB file containing Cas9 mutant of interest')
+    parser.add_argument('-o', '--output_dir', metavar='D', type=str,
+                        help='path to output directory for new PDBs')
+    args = parser.parse_args()
+
+    assert args.num_pams
+    assert args.input_pdb
+    assert args.output_dir
+    args.num_pams = int(args.num_pams) # convert string from command line to int
+    assert 64 == args.num_pams or 256 == args.num_pams
+    assert os.path.isfile(args.input_pdb)
+
+    if not os.path.exists(args.output_dir):
+        os.makedirs(args.output_dir)
+
+for i in range(args.num_pams):
+    if 64 == args.num_pams:
+        pam = dna_nts[i / 16] + dna_nts[i / 4 % 4] + dna_nts[i % 4]
+    else:
+        pam = dna_nts[i / 64] + dna_nts[i / 16 % 4] + dna_nts[i / 4 % 4] + dna_nts[i % 4]
+
+    # TGG PAM site already exists, let's skip it
+    if "tgg" == pam:
+        continue
+    # open up the file again each time, for now
+    runCommand("open " + original_pdb_path)
+    # Loop through the PAM sequence and mutate positions
+    for n in range(len(pam)):
+        base = pam[n]
+        # If the first base is T, don't mutate
+        if base == 't' and n == 0:
+            continue
+        # If the 2nd or third bases are G, don't mutate
+        if all([base == 'g', any([n == 1, n == 2])]):
+            continue
+        mutate_nt(n, base)
+    # Save and close all files
+    generate_pdb(original_pdb_path, pam)

--- a/models/tridimensional/docking_validation/chimera_generate_pams.py
+++ b/models/tridimensional/docking_validation/chimera_generate_pams.py
@@ -4,8 +4,6 @@ import chimera
 from chimera import runCommand
 from chimera import replyobj
 
-os.chdir("C:\\Users\\James\\Documents\\GitHub\\uwaterloo-igem-2015\\models\\tridimensional\\cas9_modification")
-original_pdb_path = "4UN3.clean.pdb"
 dna_nts = ['a','c','g','t']
 
 
@@ -25,13 +23,13 @@ def mutate_nt(pam_idx, base):
     runCommand("swapna " + base + " : " + pos )
     runCommand("swapna " + complement_base + " : " + complement_pos)
 
-def generate_pdb(original_pdb_path, pam_seq):
+def generate_pdb(original_pdb_basename, pam_seq):
     """Generate a new PDB file
     Args:
-        original_pdb_path: original fine basename
+        original_pdb_basename: original fine basename
         pam_seq: new PAM sequence to be listed in name
     """
-    new_pdb_path = os.path.join(args.output_dir, original_pdb_path[:4] + "." + pam_seq + ".pdb")
+    new_pdb_path = os.path.join(args.output_dir, original_pdb_basename[:4] + "." + pam_seq + ".pdb")
     runCommand("write 0 " + new_pdb_path)
     runCommand("close all")
 
@@ -67,7 +65,7 @@ for i in range(args.num_pams):
     if "tgg" == pam:
         continue
     # open up the file again each time, for now
-    runCommand("open " + original_pdb_path)
+    runCommand("open " + args.input_pdb)
     # Loop through the PAM sequence and mutate positions
     for n in range(len(pam)):
         base = pam[n]
@@ -79,4 +77,4 @@ for i in range(args.num_pams):
             continue
         mutate_nt(n, base)
     # Save and close all files
-    generate_pdb(original_pdb_path, pam)
+    generate_pdb(os.path.basename(args.input_pdb), pam)

--- a/models/tridimensional/docking_validation/chimera_generate_pams.py
+++ b/models/tridimensional/docking_validation/chimera_generate_pams.py
@@ -58,9 +58,12 @@ if __name__ == '__main__':
     assert 64 == args.num_pams or 256 == args.num_pams
     assert os.path.isfile(args.input_pdb)
 
-    if not os.path.exists(args.output_dir):
+    try: # check existence again to handle concurrency problems
         os.makedirs(args.output_dir)
-
+    except OSError as exc:
+        if exc.errno == errno.EEXIST and os.path.isdir(args.output_dir):
+            pass
+        else: raise
 
     for i in xrange(args.num_pams):
         if 3 == pam_length:

--- a/models/tridimensional/docking_validation/chimera_generate_pams.py
+++ b/models/tridimensional/docking_validation/chimera_generate_pams.py
@@ -5,10 +5,7 @@ import math
 import chimera
 from chimera import runCommand
 from chimera import replyobj
-
-
-dna_nts = ['a','c','g','t']
-original_pam_sequence = 'tgg'
+from constants import PAM_TEMPLATE_SEQUENCE, DNA_ALPHABET
 
 
 def mutate_nt(pam_idx, base):
@@ -63,10 +60,10 @@ if __name__ == '__main__':
 
 
     for i in xrange(args.num_pams):
-        if 64 == args.num_pams:
-            pam = dna_nts[i / 16] + dna_nts[i / 4 % 4] + dna_nts[i % 4]
+        if 4 == pam_length:
+            pam = DNA_ALPHABET[i / 16] + DNA_ALPHABET[i / 4 % 4] + DNA_ALPHABET[i % 4]
         else:
-            pam = dna_nts[i / 64] + dna_nts[i / 16 % 4] + dna_nts[i / 4 % 4] + dna_nts[i % 4]
+            pam = DNA_ALPHABET[i / 64] + DNA_ALPHABET[i / 16 % 4] + DNA_ALPHABET[i / 4 % 4] + DNA_ALPHABET[i % 4]
 
         # open up the file again each time, for now
         runCommand("open " + args.input_pdb)
@@ -74,7 +71,7 @@ if __name__ == '__main__':
         # Loop through the PAM sequence and mutate positions
         for pam_idx in xrange(pam_length):
             # If the nt matches the original PAM nt, don't change it
-            if original_pam_sequence[pam_idx] == pam[pam_idx]:
+            if PAM_TEMPLATE_SEQUENCE[pam_idx] == pam[pam_idx]:
                 continue
             mutate_nt(pam_idx, pam[pam_idx])
 


### PR DESCRIPTION
This script will, given a PDB containing the Cas9 variant of interest, generate new PDBs with the desired PAM site.

Unfortunately, it has to be run by Chimera's Python interpreter, since there isn't support for importing the chimera package except through the Chimera program.

I ran it from command line using the following:

```
$ chimera --script '/path/to/chimera_generate_pams.py -n 64 -i /path/to/4UN3.tgg.pdb -o /path/to/output_dir'
```

It currently works with PAMs of length 3, a slight change will need to be made for PAMs of length 4. We just need to find what position in the two chains need to be modified for a length-4-PAM (length-3-PAM is already listed in the file, as found by @mglubber)
