### PR TITLE
Added edited script to source PyRosetta properly and PyMOL_Observer basic script

### DIFF
--- a/models/tridimensional/docking_validation/pymol_observer.py
+++ b/models/tridimensional/docking_validation/pymol_observer.py
@@ -1,0 +1,28 @@
+from rosetta import *
+
+init()
+
+pose = pose_from_pdb("putsomefilehere")
+
+pyobs = PyMOL_Observer()
+pyobs.add_observer(pose)
+pyobs.pymol.keep_history(True)
+# pyobs.generalEvent()      // ???
+
+# specify scoring functions
+fa_score = get_fa_scorefxn()
+dna_score = create_score_function('dna')
+dna_score.set_weight(fa_elec, 1)
+
+# specify docking protocol
+docking = DockMCMProtocol()
+docking.set_scorefxn(dna_score)
+docking.set_scorefxn_pack(fa_score)
+docking.set_partners("B_ACD")
+
+# obtain initial and final scores after docking
+dna_init = dna_score(pose)
+fa_init = fa_score(pose)
+docking.apply(pose)
+dna_final = dna_score(pose)
+fa_final = fa_score(pose)

--- a/models/tridimensional/incomplete_scripts/SetPyRosettaEnvironment.sh
+++ b/models/tridimensional/incomplete_scripts/SetPyRosettaEnvironment.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+
+# This script intended to set Pyrosetta environment variables so user can
+# execute 'import rosetta' from any file system location, even allowing
+# the script to be a symbolic link.
+#
+# Use 'source SetPyRosettaEnvironment.sh' before starting to work with PyRosetta.
+
+READLINK=""
+if [ "Darwin" != $(uname -s) ]; then
+    # FIXME: MacOS X does not have the -f option for readlink and realpath 
+    #        is not available, either. 
+    READLINK=$(which readlink)
+fi
+
+if [[ "${BASH_SOURCE[0]}" == "" ]]; then
+    #echo "zsh like shell..."
+    OLD_PATH=`pwd`
+    if [ -n "$READLINK" ]; then
+        PYROSETTA="$( dirname $( $READLINK -f "$0" ) )"
+    else
+        PYROSETTA="$( cd "$( dirname "$0" )" && pwd )"
+    fi
+else
+    #echo "bash like shell..."
+    OLD_PATH=`pwd`
+    if [ -n "$READLINK" ]; then
+        PYROSETTA="$( dirname $( $READLINK -f "${BASH_SOURCE[0]}" ) )"
+    else
+        PYROSETTA="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+    fi
+fi
+
+
+#if [[ "$0" == "bash"  ||  "$0" == "-bash" ]]; then
+#    #echo "bash like shell..."
+#    OLD_PATH=`pwd`
+#    PYROSETTA="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+#else
+#    #echo "zsh like shell..."
+#    OLD_PATH=`pwd`
+#    PYROSETTA="$( cd "$( dirname "$0" )" && pwd )"
+#fi
+
+cd $PYROSETTA
+
+# echo "Setting PyRosetta root as:" $PYROSETTA
+
+export PYROSETTA
+export PYTHONPATH=$PYROSETTA${PYTHONPATH+:$PYTHONPATH}
+export DYLD_LIBRARY_PATH=$PYROSETTA:$PYROSETTA/rosetta${DYLD_LIBRARY_PATH+:$DYLD_LIBRARY_PATH}
+export LD_LIBRARY_PATH=$PYROSETTA:$PYROSETTA/rosetta${LD_LIBRARY_PATH+:$LD_LIBRARY_PATH}
+export PYROSETTA_DATABASE=$PYROSETTA/database
+
+# echo "Aliasing PyRosetta Toolkit GUI to pyrosetta_toolkit"
+alias pyrosetta_toolkit='python $PYROSETTA/app/pyrosetta_toolkit/pyrosetta_toolkit.py'
+
+cd "$OLD_PATH"


### PR DESCRIPTION
SetPyRosettaEnvironment.sh that allows you to use PyRosetta outside of the source folder, and PyMOL Observer script. Have a PyMOL instance open and listening for PyRosetta before running.

Currently pyobs updates on ANY event (change to pose); ~1400 events occured with DockMCMProtocol before we stopped it, and then PyMOL killed the comp with RAM usage trying to visualize those results. So visualize a smaller protocol, or might be able to use pyobs.generalEvent(parameter) in some way to change when it PyMOL updates. Not sure what generalEvent() does though, just guessing.

PyMOL_Mover() can be used to update visuals when its apply() method is called, but can't call that within DockMCMProtocol, hence the need for observer (unless we reconstruct the docking protocol algorithm ourselves).
