### PR TITLE
Update mutate_pdb.py to use protein sequence/pdb numbering rather than pose numbering

### DIFF
--- a/models/tridimensional/docking_validation/generate_pams_chimera.py
+++ b/models/tridimensional/docking_validation/generate_pams_chimera.py
@@ -82,3 +82,4 @@ if __name__ == '__main__':
 
         # save and close all files
         generate_pam_variant_chimera(pam, args.input_pdb, args.output_dir)
+

--- a/models/tridimensional/docking_validation/mutate_pdb.py
+++ b/models/tridimensional/docking_validation/mutate_pdb.py
@@ -21,7 +21,9 @@ def mutate_pose(pose, mutations):
         # ensure mutation is valid and apply it
         assert isinstance(aa_num, int)
         assert isinstance(aa_replacement, str) and len(aa_replacement) == 1
-        mutant_pose = mutate_residue(mutant_pose, aa_num, aa_replacement)
+        #Use the findPyRosettaResNum() to automatically convert from pdb to Rosetta numbering
+        pose_num = findPyRosettaResNum(mutate_pose, 'B', aa_num)
+        mutant_pose = mutate_residue(mutant_pose, pose_num, aa_replacement)
     # specify a pose packer to repack the mutation region
     pose_packer = standard_packer_task(mutant_pose)
     pose_packer.restrict_to_repacking()
@@ -33,7 +35,8 @@ def mutate_pose(pose, mutations):
     pose_packer.temporarily_fix_everything()
     # Let's release the PI domain
     for i in range(1110, 1388):
-        pose_packer.temporarily_set_pack_residue(i, True)
+        pose_num = findPyRosettaResNum(mutate_pose, 'B', aa_num)
+        pose_packer.temporarily_set_pack_residue(pose_num, True)
     # =================================
     # specify the rotamer mover and apply repacking
     packmover = PackRotamersMover(get_fa_scorefxn(), pose_packer)
@@ -61,6 +64,23 @@ def mutate_pdb(input_pdb_path, mutations, output_directory, output_id):
     pose_mutant.dump_pdb(output_pdb_path)
     return output_pdb_path
 
+
+def findPyRosettaResNum(pose,chain,pdb_res_num):
+    ''' Find the internal PyRosetta number given the protein sequence numbering.
+        Args:
+        pose: PyRosetta pose representing the pdb
+        chain: the chain the residues of interest is part or. Single character string, uppercase
+    Returns:
+        pose_res_num: the internal PyRosetta residue number from the pose
+    pdb_res_num: int, the residue number from the protein sequence or pdb to modify
+    This is helpful given that PyRosetta does not number according to the
+    protein sequence given in the pdb, which matches numbering from start to finish.
+    Especially helpful given the gaps present in the cas9 structure, and the extra
+    DNA and sgRNA chains present.
+    '''
+    pose_res_num = pose.pdb_info().pdb2pose(chain,pdb_res_num)
+    assert pose_res_num != 0; "Amino acid number %i is not a valid position in the pdb"
+    return pose_res_num
     
 if __name__ == '__main__':
     print "main behaviour not yet implemented"

--- a/models/tridimensional/docking_validation/mutate_pdb.py
+++ b/models/tridimensional/docking_validation/mutate_pdb.py
@@ -35,7 +35,7 @@ def mutate_pose(pose, mutations):
     pose_packer.temporarily_fix_everything()
     # Let's release the PI domain
     for i in range(1110, 1388):
-        pose_num = findPyRosettaResNum(mutate_pose, 'B', aa_num)
+        pose_num = findPyRosettaResNum(mutate_pose, 'B', i)
         pose_packer.temporarily_set_pack_residue(pose_num, True)
     # =================================
     # specify the rotamer mover and apply repacking
@@ -67,7 +67,7 @@ def mutate_pdb(input_pdb_path, mutations, output_directory, output_id):
 
 def findPyRosettaResNum(pose,chain,pdb_res_num):
     ''' Find the internal PyRosetta number given the protein sequence numbering.
-        Args:
+    Args:
         pose: PyRosetta pose representing the pdb
         chain: the chain the residues of interest is part or. Single character string, uppercase
     Returns:
@@ -79,8 +79,10 @@ def findPyRosettaResNum(pose,chain,pdb_res_num):
     DNA and sgRNA chains present.
     '''
     pose_res_num = pose.pdb_info().pdb2pose(chain,pdb_res_num)
-    assert pose_res_num != 0; "Amino acid number %r is not a valid position in the pose" % pdb_res_num
+    assert pose_res_num != 0, "Amino acid number %r is not a valid position in the pose" % pdb_res_num
     return pose_res_num
-    
+
+
 if __name__ == '__main__':
     print "main behaviour not yet implemented"
+ 

--- a/models/tridimensional/docking_validation/mutate_pdb.py
+++ b/models/tridimensional/docking_validation/mutate_pdb.py
@@ -79,7 +79,7 @@ def findPyRosettaResNum(pose,chain,pdb_res_num):
     DNA and sgRNA chains present.
     '''
     pose_res_num = pose.pdb_info().pdb2pose(chain,pdb_res_num)
-    assert pose_res_num != 0; "Amino acid number %i is not a valid position in the pdb"
+    assert pose_res_num != 0; "Amino acid number %r is not a valid position in the pose" % pdb_res_num
     return pose_res_num
     
 if __name__ == '__main__':

--- a/models/tridimensional/docking_validation/mutate_pdb.py
+++ b/models/tridimensional/docking_validation/mutate_pdb.py
@@ -21,8 +21,8 @@ def mutate_pose(pose, mutations):
         # ensure mutation is valid and apply it
         assert isinstance(aa_num, int)
         assert isinstance(aa_replacement, str) and len(aa_replacement) == 1
-        #Use the findPyRosettaResNum() to automatically convert from pdb to Rosetta numbering
-        pose_num = findPyRosettaResNum(mutate_pose, 'B', aa_num)
+        #Use the find_pyrosetta_res_num() to automatically convert from pdb to Rosetta numbering
+        pose_num = find_pyrosetta_res_num(mutate_pose, 'B', aa_num)
         mutant_pose = mutate_residue(mutant_pose, pose_num, aa_replacement)
     # specify a pose packer to repack the mutation region
     pose_packer = standard_packer_task(mutant_pose)
@@ -35,7 +35,7 @@ def mutate_pose(pose, mutations):
     pose_packer.temporarily_fix_everything()
     # Let's release the PI domain
     for i in range(1110, 1388):
-        pose_num = findPyRosettaResNum(mutate_pose, 'B', i)
+        pose_num = find_pyrosetta_res_num(mutate_pose, 'B', i)
         pose_packer.temporarily_set_pack_residue(pose_num, True)
     # =================================
     # specify the rotamer mover and apply repacking
@@ -65,7 +65,7 @@ def mutate_pdb(input_pdb_path, mutations, output_directory, output_id):
     return output_pdb_path
 
 
-def findPyRosettaResNum(pose,chain,pdb_res_num):
+def find_pyrosetta_res_num(pose,chain,pdb_res_num):
     ''' Find the internal PyRosetta number given the protein sequence numbering.
     Args:
         pose: PyRosetta pose representing the pdb

--- a/models/tridimensional/incomplete_scripts/generate_pams_chimera_validation_test.py
+++ b/models/tridimensional/incomplete_scripts/generate_pams_chimera_validation_test.py
@@ -7,9 +7,17 @@ import sys
 import chimera
 from chimera import runCommand
 from chimera import replyobj
+HOME = os.getenv("HOME")
+sys.path.append(HOME+'/github/uwaterloo-igem-2015/models/tridimensional/docking_validation')
 from constants import PAM_TEMPLATE_SEQUENCE, DNA_ALPHABET
 from utility import pam_string_from_int 
-
+'''
+Mark Lubberts - 01/08/2015
+I'm checking if the higher scoring in the tgg variants is due to the fact that
+they aren't mutated, rather than actually binding better. tgg bases are switched
+with identical nucleotide instead of being skipped, to ensure that scoring is 
+nucleotide specific.
+'''
 
 def mutate_nt(pam_idx, base):
     """Mutate a base pair at pam_idx to base
@@ -75,9 +83,11 @@ if __name__ == '__main__':
 
         # loop through the PAM sequence and mutate positions
         for pam_idx in xrange(pam_length):
+            '''This has been commented out so that all nucleotides are changed
+            regardless of whether the match the original pdb or not.'''
             # If the nt matches the original PAM nt, don't change it
-            if PAM_TEMPLATE_SEQUENCE[pam_idx] == pam[pam_idx]:
-                continue
+            #if PAM_TEMPLATE_SEQUENCE[pam_idx] == pam[pam_idx]:
+            #    continue
             mutate_nt(pam_idx, pam[pam_idx])
 
         # save and close all files

--- a/models/tridimensional/incomplete_scripts/mutate_to_VQR_EQR.py
+++ b/models/tridimensional/incomplete_scripts/mutate_to_VQR_EQR.py
@@ -22,19 +22,27 @@ def mutate_pose(pose, mutations):
         assert isinstance(aa_replacement, str) and len(aa_replacement) == 1
         scorefxn = get_fa_scorefxn()
         pose_num = findPyRosettaResNum(mutant_pose, 'B',aa_num,)
-        mutant_pose = mutate_residue(mutant_pose, aa_num, aa_replacement, 0, scorefxn)
+        # Use this mutate_residue for automatic repacking based on distance (angstroms)
+        # distance can be set with using an int in the fourth arguement position. Please run 0,2,5
+        mutant_pose = mutate_residue(mutant_pose, pose_num, aa_replacement, 0, scorefxn)
+        # use the mutate_residue below for manually specifying packing residues with the pose_packer
+        # code below. Try the entire pdb_range, as well as setting to the aa_num list passed to
+        # the function
+        # mutant_pose = mutate_residue(mutate_residue, pose_num, aa_replacement)
     # kims lines from D050 example
     # =================================
-    #pose_packer = standard_packer_task(mutant_pose)
-    #pose_packer.restrict_to_repacking()
+    # pose_packer = standard_packer_task(mutant_pose)
+    # pose_packer.restrict_to_repacking()
     # This is a hack, but I want to test. Can't set a movemap, resfiles
     # might be the way to go. Freeze all residues. 
-    #pose_packer.temporarily_fix_everything()
+    # pose_packer.temporarily_fix_everything()
     # Let's release the PI domain
-    #for i in range(1110, 1388):
-    #    pose_packer.temporarily_set_pack_residue(i,True)
-    #packmover = PackRotamersMover(scorefxn, pose_packer)
-    #packmover.apply(mutant_pose)
+    # for i in range(1097, 1364):
+    #     pose_num = findPyRosettaResNum(mutant_pose, 'B', i)
+    #     if pose_num != 0:
+    #         pose_packer.temporarily_set_pack_residue(pose_num,True)
+    # packmover = PackRotamersMover(scorefxn, pose_packer)
+    # packmover.apply(mutant_pose)
     # =================================
     return mutant_pose
 
@@ -83,5 +91,4 @@ if __name__ == '__main__':
     residue numbering, the offset is not constant either. The mutant locations
     in this script have been verified using PyMOL.
     '''
-    mutate_pdb("4UN3.tgg.pdb", [(1135,'V'),(1335,'Q'),(1337,'R')],"mutate_folder",'4UN3.VQR')
-    mutate_pdb("4UN3.tgg.pdb", [(1135,'E'),(1335,'Q'),(1337,'R')],"mutate_folder",'4UN3.EQR')
+    mutate_pdb("4UN3_trimmed.tgg.pdb", [(1135,'V'),(1335,'Q'),(1337,'R')],"mutate_folder",'4UN3.VQR')

--- a/models/tridimensional/incomplete_scripts/mutate_to_VQR_EQR.py
+++ b/models/tridimensional/incomplete_scripts/mutate_to_VQR_EQR.py
@@ -39,8 +39,7 @@ def mutate_pose(pose, mutations):
     # Let's release the PI domain
     # for i in range(1097, 1364):
     #     pose_num = findPyRosettaResNum(mutant_pose, 'B', i)
-    #     if pose_num != 0:
-    #         pose_packer.temporarily_set_pack_residue(pose_num,True)
+    #     pose_packer.temporarily_set_pack_residue(pose_num,True)
     # packmover = PackRotamersMover(scorefxn, pose_packer)
     # packmover.apply(mutant_pose)
     # =================================
@@ -60,6 +59,7 @@ def findPyRosettaResNum(pose,chain,pdb_res_num):
     DNA and sgRNA chains present.
     '''
     pose_res_num = pose.pdb_info().pdb2pose(chain,pdb_res_num)
+    assert pose_res_num != 0; "Amino acid residue number %r is not a valid position in the pose." % pdb_res_num
     return pose_res_num
 
 def mutate_pdb(input_pdb_path, mutations, output_directory, output_id):

--- a/models/tridimensional/incomplete_scripts/mutate_to_VQR_EQR.py
+++ b/models/tridimensional/incomplete_scripts/mutate_to_VQR_EQR.py
@@ -21,7 +21,7 @@ def mutate_pose(pose, mutations):
         assert isinstance(aa_num, int)
         assert isinstance(aa_replacement, str) and len(aa_replacement) == 1
         scorefxn = get_fa_scorefxn()
-        pose_num = findPyRosettaResNum(mutant_pose, 'B',aa_num,)
+        pose_num = find_py_rosetta_res_num(mutant_pose, 'B',aa_num,)
         # Use this mutate_residue for automatic repacking based on distance (angstroms)
         # distance can be set with using an int in the fourth arguement position. Please run 0,2,5
         mutant_pose = mutate_residue(mutant_pose, pose_num, aa_replacement, 0, scorefxn)
@@ -38,7 +38,7 @@ def mutate_pose(pose, mutations):
     # pose_packer.temporarily_fix_everything()
     # Let's release the PI domain
     # for i in range(1097, 1364):
-    #     pose_num = findPyRosettaResNum(mutant_pose, 'B', i)
+    #     pose_num = find_py_rosetta_res_num(mutant_pose, 'B', i)
     #     pose_packer.temporarily_set_pack_residue(pose_num,True)
     # packmover = PackRotamersMover(scorefxn, pose_packer)
     # packmover.apply(mutant_pose)
@@ -46,7 +46,7 @@ def mutate_pose(pose, mutations):
     return mutant_pose
 
 
-def findPyRosettaResNum(pose,chain,pdb_res_num):
+def find_py_rosetta_res_num(pose,chain,pdb_res_num):
     ''' Find the internal PyRosetta number given the protein sequence numbering.
     Args:
         pose: PyRosetta pose representing the pdb

--- a/models/tridimensional/incomplete_scripts/mutate_to_VQR_EQR.py
+++ b/models/tridimensional/incomplete_scripts/mutate_to_VQR_EQR.py
@@ -48,7 +48,7 @@ def mutate_pose(pose, mutations):
 
 def findPyRosettaResNum(pose,chain,pdb_res_num):
     ''' Find the internal PyRosetta number given the protein sequence numbering.
-        Args:
+    Args:
         pose: PyRosetta pose representing the pdb
         chain: the chain the residues of interest is part or. Single character string, uppercase
     Returns:
@@ -83,7 +83,7 @@ def mutate_pdb(input_pdb_path, mutations, output_directory, output_id):
     pose_mutant.dump_pdb(output_pdb_path)
     return output_pdb_path
     
-    
+
 if __name__ == '__main__':
     '''
     This script creates the VQR and EQR mutants from the Kleinstiver 2015 paper

--- a/models/tridimensional/incomplete_scripts/mutate_to_VQR_EQR.py
+++ b/models/tridimensional/incomplete_scripts/mutate_to_VQR_EQR.py
@@ -45,6 +45,7 @@ def mutate_pose(pose, mutations):
     # =================================
     return mutant_pose
 
+
 def findPyRosettaResNum(pose,chain,pdb_res_num):
     ''' Find the internal PyRosetta number given the protein sequence numbering.
         Args:
@@ -59,8 +60,9 @@ def findPyRosettaResNum(pose,chain,pdb_res_num):
     DNA and sgRNA chains present.
     '''
     pose_res_num = pose.pdb_info().pdb2pose(chain,pdb_res_num)
-    assert pose_res_num != 0; "Amino acid residue number %r is not a valid position in the pose." % pdb_res_num
+    assert pose_res_num != 0, "Amino acid residue number %r is not a valid position in the pose." % pdb_res_num
     return pose_res_num
+
 
 def mutate_pdb(input_pdb_path, mutations, output_directory, output_id):
     """Create a new pdb (<output_filename>.pdb) in the output directory containing specified mutations
@@ -80,6 +82,7 @@ def mutate_pdb(input_pdb_path, mutations, output_directory, output_id):
     output_pdb_path = os.path.join(output_directory, output_id + ".pdb")
     pose_mutant.dump_pdb(output_pdb_path)
     return output_pdb_path
+    
     
 if __name__ == '__main__':
     '''


### PR DESCRIPTION
Update mutate_pdb.py to use protein sequence/pdb numbering rather than pose numbering. Added a function converts the numbering sequence from the pdb/protein sequence (which is consistent across papers and pdb files) to the pose numbering (which varies with the pose) automatically. Allows mutations to be specified using notation directly from papers such as Kleinstivee et al. 2015.
