### PR TITLE
Score 1 PAM tool at a time (3DNA, Chimera)

### DIFF
--- a/models/tridimensional/docking_validation/constants.py
+++ b/models/tridimensional/docking_validation/constants.py
@@ -3,6 +3,7 @@ DNA_ALPHABET = "acgt"  # used for iterating over pam variants
 PAM_TEMPLATE_SEQUENCE = "tggt"  # pam sequence for the progenitor file
 
 # IO constants
+PAM_TOOLS = ["Chimera", "3DNA"]
 SCOREFILE_LINES = 6  # number of lines in score .txt files from dock_variants.py
 CSV_HEADER = ['PAM_1', 'PAM_2', 'PAM_3', 'PAM_4', 'Tool', 'Init FA', 'Final FA', 'Init DNA', 'Final DNA',
               'Total Time', 'Dock Time']

--- a/models/tridimensional/docking_validation/dock_variants.py
+++ b/models/tridimensional/docking_validation/dock_variants.py
@@ -32,12 +32,12 @@ def write_dock_stats(score_directory, filename, dock_stats, time_diff_total, tim
     return
 
 
-def dock_simple(pose, dock_partners="B_ACD", foldtree=None):
+def dock_simple(pose, dock_partners, foldtree):
     """Coarse docking of a pose representing a PAM / program variant
     Args:
         pose: pose loaded from pdb to be docked / scored
         dock_partners: [default: "B_ACD"] string for thee set_partners(...) method for docking
-        foldtree: [default: None] string for the 2nd setup_foldtree(...) argument, None implies default foldtree
+        foldtree: [default: None] string (e.g. "B_CD") for the 2nd setup_foldtree(...) argument, None implies default foldtree
     Returns:
         list of scores in the form [fa_init, fa_final, dna_init, dna_final]
     Notes:
@@ -107,7 +107,7 @@ def dock_variants(pam_variants, path_to_scores, path_to_pdbs='', dock_partners="
         if complex_docking_flag:
             dock_stats = dock_complex(loaded_pose)
         else:
-            dock_stats = dock_simple(loaded_pose, dock_partners=dock_partners, foldtree=foldtree)
+            dock_stats = dock_simple(loaded_pose, dock_partners, foldtree)
 
         time_final = time()
         time_diff_total = time_final - time_init_total

--- a/models/tridimensional/docking_validation/dock_variants.py
+++ b/models/tridimensional/docking_validation/dock_variants.py
@@ -11,10 +11,6 @@ from results_csv import results_to_csv
 from utility import pam_string_from_int
 
 
-# variations to account for
-
-
-
 def write_dock_stats(score_directory, filename, dock_stats, time_diff_total, time_diff_docking):
     """Writes separate files for each variant
     Notes:

--- a/models/tridimensional/docking_validation/dock_variants.py
+++ b/models/tridimensional/docking_validation/dock_variants.py
@@ -6,13 +6,13 @@ from time import time
 
 from rosetta import *
 
-from constants import SCOREFILE_LINES
+from constants import PAM_TOOLS, SCOREFILE_LINES
 from results_csv import results_to_csv
 from utility import pam_string_from_int
 
 
 # variations to account for
-programs = ["Chimera", "3DNA"]
+
 
 
 def write_dock_stats(score_directory, filename, dock_stats, time_diff_total, time_diff_docking):
@@ -81,8 +81,8 @@ def dock_complex(pose):
 
 
 def dock_variants(pam_variants, path_to_scores, path_to_pdbs='', dock_partners="B_ACD", foldtree=None,
-                  pam_length=4, complex_docking_flag=False):
-    """Docks and scores 2 pdbs for each PAM variant (one for each nt program) using simple docking
+                  pam_length=4, pam_tool='Chimera', complex_docking_flag=False):
+    """Docks and scores a pdb for each PAM variant (created using pam_tool) using simple docking
     Args:
         pam_variants: list of integers (any from 0 to 63 without repeats) which map to pam strings
         path_to_scores: path to the subdirectory of "results" where the variants are stored
@@ -90,36 +90,37 @@ def dock_variants(pam_variants, path_to_scores, path_to_pdbs='', dock_partners="
         dock_partners: [default: "B_ACD"] string for thee set_partners(...) method for docking
         foldtree: [default: None] string for the 2nd setup_foldtree(...) argument, None implies default foldtree
         pam_length: [default: 4] length of the pam sequence to be investigated
+        pam_tool: [default: 'Chimera'] either "3DNA" or "Chimera"
         complex_docking_flag: [default: False] if True, use complex dock function (NOT IMPLEMENTED)
     Notes:
     - creates a text file (e.g. 'results_agg_Chimera.txt') for each variant
     - path to variants is typically root/results/<timestamped folder>/<variants>
     - assumes current directory is the root of a folder that contains pdbs in Chimera and 3DNA directories
     """
+    assert pam_tool in PAM_TOOLS
     for idx in pam_variants:
         variant = pam_string_from_int(idx, pam_length)
-        for program in programs:
-            print "Running for variant: %s_%s" % (variant, program)
-            pdb_path = os.path.join(path_to_pdbs, program, "4UN3." + variant + ".pdb")
+        print "Running for variant: %s_%s" % (variant, pam_tool)
+        pdb_path = os.path.join(path_to_pdbs, pam_tool, "4UN3." + variant + ".pdb")
 
-            # track runtime while loading and passing pose to the simple docker
-            time_init_total = time()
-            loaded_pose = pose_from_pdb(pdb_path)
+        # track runtime while loading and passing pose to the simple docker
+        time_init_total = time()
+        loaded_pose = pose_from_pdb(pdb_path)
 
-            time_init_docking = time()
-            if complex_docking_flag:
-                dock_stats = dock_complex(loaded_pose)
-            else:
-                dock_stats = dock_simple(loaded_pose)
+        time_init_docking = time()
+        if complex_docking_flag:
+            dock_stats = dock_complex(loaded_pose)
+        else:
+            dock_stats = dock_simple(loaded_pose)
 
-            time_final = time()
-            time_diff_total = time_final - time_init_total
-            time_diff_docking = time_final - time_init_docking
+        time_final = time()
+        time_diff_total = time_final - time_init_total
+        time_diff_docking = time_final - time_init_docking
 
-            # write results to file
-            results_filename = variant + "_" + program + ".txt"
-            write_dock_stats(path_to_scores, results_filename, dock_stats, time_diff_total, time_diff_docking)
-            print "Finished writing scores for variant: %s_%s" % (variant, program)
+        # write results to file
+        results_filename = variant + "_" + pam_tool + ".txt"
+        write_dock_stats(path_to_scores, results_filename, dock_stats, time_diff_total, time_diff_docking)
+        print "Finished writing scores for variant: %s_%s" % (variant, pam_tool)
     return
 
 
@@ -144,6 +145,8 @@ if __name__ == '__main__':
                         type=bool, help='[switch] compile scores to csv (default: "False")')
     parser.add_argument('--pam64', metavar='B', nargs='?', const=3, default=4,
                         type=int, help='[switch] assume 64 pam variants (default: assume 256)')
+    parser.add_argument('--alt_tool', metavar='S', nargs='?', const='3DNA', default='Chimera',
+                        type=str, help='[switch] use 3DNA pdbs instead of Chimera (default: Chimera)')
     args = parser.parse_args()
 
     # setup range of pam variants
@@ -168,8 +171,8 @@ if __name__ == '__main__':
     # initialize pyrosetta and score variants
     init(extra_options="-mute all")  # reduce rosetta print calls
     dock_variants(pam_variants_to_score, path_to_scores, dock_partners=args.set_partners, foldtree=args.setup_foldtree,
-                  path_to_pdbs=args.pdb_dir, complex_docking_flag=args.complex, pam_length=args.pam64)
+                  path_to_pdbs=args.pdb_dir, complex_docking_flag=args.complex, pam_length=args.pam64, pam_tool=args.alt_tool)
 
     # collect score txt files into a csv
     if args.csv:
-        results_to_csv(path_to_scores)
+        results_to_csv(path_to_scores, pam_tool=args.alt_tool)

--- a/models/tridimensional/docking_validation/dock_variants.py
+++ b/models/tridimensional/docking_validation/dock_variants.py
@@ -107,7 +107,7 @@ def dock_variants(pam_variants, path_to_scores, path_to_pdbs='', dock_partners="
         if complex_docking_flag:
             dock_stats = dock_complex(loaded_pose)
         else:
-            dock_stats = dock_simple(loaded_pose)
+            dock_stats = dock_simple(loaded_pose, dock_partners=dock_partners, foldtree=foldtree)
 
         time_final = time()
         time_diff_total = time_final - time_init_total

--- a/models/tridimensional/docking_validation/results_csv.py
+++ b/models/tridimensional/docking_validation/results_csv.py
@@ -2,10 +2,7 @@ import argparse
 import csv
 import os
 
-from constants import CSV_HEADER, SCOREFILE_LINES
-
-
-categories = ['Chimera', '3DNA']  # tools used to create 64 or 256 pam variants
+from constants import CSV_HEADER, PAM_TOOLS, SCOREFILE_LINES
 
 
 def get_pam_and_tool_from_filename(score_filename):
@@ -24,7 +21,7 @@ def get_pam_and_tool_from_filename(score_filename):
 
 
 def get_score_info(score_dir, score_filename):
-    """Extracts pam/tool info and scores as a list from a score file
+    """Extracts pam/tool info and scores as a list from a score fileW
     Args:
         score_dir: path to score file directory
         score_file: specific score file name (including .txt)
@@ -38,7 +35,7 @@ def get_score_info(score_dir, score_filename):
             Final DNA score:  -207.921
             Total time:  857.995
             Dock time:  600.995
-        Expected return: ['a', 'g', 'g', 't', 'Chimera', '2465.219', ..., '600.995']
+        Expected return: ['2465.219', ..., '600.995']
     """
     # read contents of textfile
     with open(os.path.join(score_dir, score_filename)) as f:
@@ -48,38 +45,35 @@ def get_score_info(score_dir, score_filename):
     return [file_lines[i].split(" ")[-1][:-1] for i in xrange(SCOREFILE_LINES)]
 
 
-def results_to_csv(score_file_directory):
+def results_to_csv(score_file_directory, pam_tool='Chimera'):
     """Appends data from each result file to an appropriate csv within score_file_directory
     Args:
         score_file_directory: path to score files
+        pam_tool: [string] either "3DNA" or "Chimera"
     Returns:
         None
-    Notes:
-        - currently creates / looks for a csv for each PAM tool
     """
     # csv prep
-    csv_dict = {elem: csv.writer(open(os.path.join(score_file_directory, '%s.csv' % elem), 'a'), lineterminator='\n')
-                for elem in categories}
-    for elem in categories:
-        filename = os.path.join(score_file_directory, '%s.csv' % elem)
-        if os.stat(filename).st_size == 0:  # if file empty, write header
-            print "%s is empty, adding header" % filename
-            csv_dict[elem].writerow(CSV_HEADER)
-        else:
-            print "%s already exists" % filename
+    assert pam_tool in PAM_TOOLS
+    path_csv = os.path.join(score_file_directory, '%s.csv' % pam_tool)
+    score_writer = csv.writer(open(path_csv, 'a'), lineterminator='\n')
+    if os.stat(path_csv).st_size == 0:  # if file empty, write header
+        print "%s is empty, adding header" % path_csv
+        score_writer.writerow(CSV_HEADER)
+    else:
+        print "%s already exists" % path_csv
     # append all data to csv
     for i, score_filename in enumerate(os.listdir(score_file_directory)):
-        if score_filename[-4:] == '.txt':
-            pam, pam_tool = get_pam_and_tool_from_filename(score_filename)
+        if score_filename[-4:] == '.txt' and pam_tool in score_filename:
+            pam, tool = get_pam_and_tool_from_filename(score_filename)
             assert len(pam) == 3 or len(pam) == 4
-            assert pam_tool in categories
+            assert tool == pam_tool
             score_info = get_score_info(score_file_directory, score_filename)
             csv_row = list(pam) + [pam_tool] + score_info  # all elements must be lists to append them
-            csv_dict[pam_tool].writerow(csv_row)
-    # close csvs
-    for elem in categories:
-        with open(os.path.join(score_file_directory, '%s.csv' % elem), 'a') as f:
-            f.close()
+            score_writer.writerow(csv_row)
+    # close csv
+    with open(path_csv, 'a') as f:
+        f.close()
     print "csv writing complete"
     return
 
@@ -87,7 +81,9 @@ def results_to_csv(score_file_directory):
 if __name__ == '__main__':
     # argument parsing
     parser = argparse.ArgumentParser(description='Compile score files into a csv.')
-    parser.add_argument('results_dir', metavar='D', type=str, help='directory of score files to collect')
+    parser.add_argument('--results_dir', metavar='D', type=str, help='directory of score files to collect')
+    parser.add_argument('--alt_tool', metavar='S', nargs='?', const='3DNA', default='Chimera',
+                        type=str, help='[switch] compile 3DNA score files (default: Chimera)')
     args = parser.parse_args()
     # write to csv
-    results_to_csv(args.results_dir)
+    results_to_csv(args.results_dir, pam_tool=args.alt_tool)


### PR DESCRIPTION
- both results_csv and dock_variants changed to use one of the tools at a time
- default tool is 'Chimera'
- new param for each script: --alt_tool
  - flips switch to use 3DNA instead of Chimera (for pdb loading and score compiling into csv)
- note that the assumed directory structure of base/Chimera or base/3DNA hasn't changed
