### PR TITLE
Fixed issue with dock_variants.py not properly modifying the foldtree…

### DIFF
--- a/models/tridimensional/docking_validation/dock_variants.py
+++ b/models/tridimensional/docking_validation/dock_variants.py
@@ -110,7 +110,7 @@ def dock_variants(pam_variants, path_to_scores, path_to_pdbs='', dock_partners="
             if complex_docking_flag:
                 dock_stats = dock_complex(loaded_pose)
             else:
-                dock_stats = dock_simple(loaded_pose)
+                dock_stats = dock_simple(loaded_pose, dock_partners, foldtree)
 
             time_final = time()
             time_diff_total = time_final - time_init_total


### PR DESCRIPTION
… and set_partners based on the argparser. function dock_simple was set to use default values for the fold tree and set partners if none were provided. The function call within the main dock_variants function was not updated to pass values from the argparser to dock_simple. This meant that the fold tree and docking partners did not change, regardless of what arguements were passed to the script.
