### PR TITLE
2 new files to make CSV results parsing easier

### DIFF
--- a/models/tridimensional/docking_validation/append_csv_results.sh
+++ b/models/tridimensional/docking_validation/append_csv_results.sh
@@ -10,8 +10,13 @@ if [ -z "$1" ]; then
 fi
 
 outcsv=$csv_dir"/"$(basename "$csv_dir").csv
-echo "Appending all CSVs found in $csv_dir"
-echo "to $outcsv..."
+if [ -e $outcsv ]; then
+    echo "ERROR: Output file $outcsv already exists!"
+    exit 1
+else
+    echo "Appending all CSVs found in $csv_dir"
+    echo "to $outcsv..."
+fi
 
 # Find constants.py, assuming it is stored in the same directory as this script
 docking_validation_dir=$( cd "$(dirname "${BASH_SOURCE[0]}" ) " && pwd)

--- a/models/tridimensional/docking_validation/append_csv_results.sh
+++ b/models/tridimensional/docking_validation/append_csv_results.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+# Accept a single directory as an argument, find all CSVs in that directory (& sub-directories) and append them
+# to a single file in the directory with an additional column of the original filename
+
+csv_dir=$1
+if [ -z "$1" ]; then
+    echo "ERROR: requires csv_dir argument"
+    echo "Example: append_results_csv.sh /results/csvs_July30"
+    exit 1
+fi
+
+outcsv=$csv_dir"/"$(basename "$csv_dir").csv
+echo "Appending all CSVs found in $csv_dir"
+echo "to $outcsv..."
+
+# Find constants.py, assuming it is stored in the same directory as this script
+docking_validation_dir=$( cd "$(dirname "${BASH_SOURCE[0]}" ) " && pwd)
+constants="$(dirname $docking_validation_dir)/constants.py"
+
+# Combine the line that starts "CSV HEADER" & the subsequent line, keep only what is between the square brackets, then
+# remove all the quote and whitespace characters -> gives CSV header as a single CSV line
+csv_cols=$(grep -A 1 "CSV_HEADER" $constants | tr '\n' ' '  | sed 's/.*\[\(.*\)\].*/\1/' | sed $'s/\'//g' | sed -e 's/\s//g')
+
+# Initialize output CSV
+echo $outcsv
+echo "$csv_cols,run_folder" > "$outcsv"
+
+# Find all CSV in supplied directory
+find "$csv_dir" -name '*.csv' -print0 | while read -d '' -r csv_file; do
+    # Assume the dir containing the CSVs has a decsriptive name
+    label=$(basename "$(dirname "$csv_file")")
+    echo "Appending from $label..."
+
+    # Pass contents of CSV file except header to awk, which adds column to the end containing label variable
+    cat "$csv_file" | tail -n+2 | awk -v label="$label" -F, '{$(NF+1)=label;}1' OFS=, >> "$outcsv"
+done
+
+echo "File $outcsv finished!"

--- a/models/tridimensional/docking_validation/join_csv_results.py
+++ b/models/tridimensional/docking_validation/join_csv_results.py
@@ -1,0 +1,80 @@
+import argparse
+import os.path
+import fnmatch
+import datetime
+import csv
+
+from collections import defaultdict
+
+from constants import CSV_HEADER, PAM_TOOLS
+
+def locate(pattern, root=os.curdir):
+    """Locate all files matching supplied filename pattern in and below supplied root directory.
+    From http://code.activestate.com/recipes/499305-locating-files-throughout-a-directory-tree/
+    """
+    print pattern
+    for path, dirs, files in os.walk(os.path.abspath(root)):
+        for filename in fnmatch.filter(files, pattern):
+            yield os.path.join(path, filename)
+
+
+if __name__ == '__main__':
+    # create parser and parse arguments
+    parser = argparse.ArgumentParser(description='Join CSV results from a directory into a single file')
+    parser.add_argument('--csv_dir', metavar='D', default='', type=str,
+                        help='path to directory containing CSVs to merge (default: ".")')
+    parser.add_argument('-o', '--output_dir', metavar='D', type=str,
+                        help='path to output directory for merged CSV')
+    parser.add_argument('--merge_stat', metavar='S', default="Final DNA", type=str,
+                        help='string of CSV column to merge, matching header (default: "Final DNA")')
+    parser.add_argument('--alt_tool', metavar='S', nargs='?', const='3DNA', default='Chimera',
+                        type=str, help='[switch] use 3DNA csvs instead of Chimera (default: Chimera)')
+    args = parser.parse_args()
+
+    assert args.merge_stat in CSV_HEADER, "--merge_stat %r is not a recognized CSV header column" % args.merge_stat
+    assert os.path.isdir(args.csv_dir), "--csv_dir %r is not a directory, check provided option" % args.csv_dir
+    assert args.alt_tool in PAM_TOOLS, "--alt_tool not in list of accepted PAM tools"
+
+    # Setup output path for scoring
+    if args.output_dir is not None:
+        csv_output_dir = args.output_dir
+    else:
+        timestamp = datetime.datetime.now().strftime("%Y-%m-%d %I.%M.%S%p")
+        csv_output_dir = os.path.join("results", timestamp)
+        os.makedirs(csv_output_dir)
+
+    # For each CSV, the column containing the merge_stat will be associated in a dictionary with the PAM
+    merge_stat_idx = CSV_HEADER.index(args.merge_stat)
+    joined_colnames = ['pam']
+    csvs_to_join = []
+
+    # Find all CSVs in directory
+    print "Locating CSVs in "+args.csv_dir+"..."
+    for csv_to_join in locate("*"+args.alt_tool+"*.csv", args.csv_dir):
+
+        # Assume the directory containing the csv has a descriptive name, use as column name
+        joined_colnames.append(os.path.basename(os.path.dirname(csv_to_join)))
+        dict_to_append = {}
+
+        # Read every CSV for the column of interest
+        with open(csv_to_join) as c:
+            r = csv.reader(c, delimiter=',')
+            for row in r:
+                pam_key = ''.join(row[0:4])
+                merge_stat_val = row[merge_stat_idx]
+                dict_to_append[pam_key] = merge_stat_val
+
+        csvs_to_join.append(dict(dict_to_append))
+
+    # Join the list of dictionaries on chosen column
+    joined_csv = defaultdict(list)
+    for d in csvs_to_join:
+        for key, value in d.iteritems():
+            joined_csv[key].append(value)
+
+    # Print to a new CSV
+    with open(os.path.join(csv_output_dir, 'joined_csv_results.csv'), 'wb') as f:
+        w = csv.writer(f)
+        w.writerow(joined_colnames)  # removes trailing comma
+        for key, value in joined_csv.iteritems():
+            w.writerow([key] + value)

--- a/models/tridimensional/docking_validation/join_csv_results.py
+++ b/models/tridimensional/docking_validation/join_csv_results.py
@@ -1,12 +1,12 @@
 import argparse
-import os.path
-import fnmatch
-import datetime
 import csv
+import datetime
+import fnmatch
+import os.path
 
 from collections import defaultdict
-
 from constants import CSV_HEADER, PAM_TOOLS
+
 
 def locate(pattern, root=os.curdir):
     """Locate all files matching supplied filename pattern in and below supplied root directory.


### PR DESCRIPTION
**append_csv_results.sh** intended to help with comparing across multiple runs, just dumps all the CSV from a directory into a single file
**join_csv_results.py** accepts a directory combines all the entries of a specific column name (defaults to 'Final DNA') in that directory's CSVs into a single output file. it works right now but could use some refactoring, I think it has more intermediate variables than necessary for the CSV joining
