### PR TITLE
Biologically-based Cas9 Concentration

### DIFF
--- a/models/targeting/genome_plot.py
+++ b/models/targeting/genome_plot.py
@@ -138,7 +138,7 @@ def genome_plot_polar(genome, genome_label, time=None, output_path=None, flag_sh
 
 if __name__ == '__main__':
     from init_genome_camv import init_genome_camv, init_targets_all_domains
-    complex_concentration = 135000000000
+    complex_concentration = 22.101 # nM
     dt = 0.1
     pseudo_targets = init_targets_all_domains(complex_concentration)
     genome_camv = init_genome_camv(pseudo_targets)

--- a/models/targeting/genome_simulation.py
+++ b/models/targeting/genome_simulation.py
@@ -25,7 +25,7 @@ for dirs in dir_list:
         os.makedirs(dirs)
 
 # simulation parameters (time in seconds)
-complex_concentration = 135000000000
+complex_concentration = 22.101 # nM
 dt = 1.0
 t0 = 0.0
 t1 = 3600.0  # 3600.0  # 18.0


### PR DESCRIPTION
This is only ~somewhat~ biologically-based, but [Hsu et al. (2013)](http://www.ncbi.nlm.nih.gov/pmc/articles/PMC3969858/) were testing the effect of Cas9 concentration on sgRNA specificity and varied "transfected DNA amount from 7.1 × 10^−10 to 1.8 × 10^−11 nmol/cell. I then averaged the mean cell volume of several arabidopsis tissue types at 16 days, which was 3.2125 x 10^-14 m^3/cell to get a range for Cas9 concentration per cell from 22.101 nM to 0.56 nM.

Only 22.101 nM (upper end of range) is used here, partly because we put our Cas9 construct under the 35S promoter and this is supposedly [expresses lots of Cas9](http://www.cellecta.com/crispr-knockout-rate-dependent-on-cas9-expression-levels/))
